### PR TITLE
Containerize wheel build for local development

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,5 @@
+target/
+Dockerfile
+docker-compose.yml
+__pycache__/
+**/libm.so.6

--- a/.dockerignore
+++ b/.dockerignore
@@ -1,5 +1,3 @@
 target/
 Dockerfile
-docker-compose.yml
 __pycache__/
-**/libm.so.6

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,25 @@
+##############################
+# Stage 1 – build the wheel  #
+##############################
+FROM ghcr.io/pyo3/maturin:latest AS builder
+
+RUN yum install -y openssl-devel
+
+# Build‑time arguments
+ARG OS
+ARG ARCH
+ARG PYTHON_VERSION
+
+ENV PATH="/opt/python/cp${PYTHON_VERSION}-cp${PYTHON_VERSION}/bin:$PATH"
+
+RUN cargo install cargo-make
+WORKDIR /io
+COPY . .
+
+RUN cargo make build-${OS}-${ARCH}
+
+#################################
+# Stage 2 – export the wheels   #
+#################################
+FROM scratch AS export
+COPY --from=builder /io/target/wheels /wheels

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # KepLemon
 
 [Citra Space Corporation's](https://citra.space) Rust-accelerated astrodynamics package built on the shared libraries
-provided by [space-track](https://space-track.org).  Please visit the [documentation](https://keplemon.citra.space)
+provided by [space-track](https://space-track.org). Please visit the [documentation](https://keplemon.citra.space)
 page for additional details.
 
 ## Installation
@@ -20,6 +20,19 @@ installed locally by following the steps below.
 3. `cargo make build-<os>-<architecture>` (e.g. for Linux x86 `cargo make build-linux-amd`)
 4. `pip install target/wheels/*.whl`
 
+To avoid potential conflicts with system libraries, you can alternatively build the wheel using Docker.
+
+```bash
+docker buildx build \
+  --build-arg OS="${OS:-linux}" \
+  --build-arg ARCH="${ARCH:-amd}" \
+  --build-arg PYTHON_VERSION="${PYTHON_VERSION:-310}" \
+  --output type=local,dest=./target .
+```
+
+Then install the wheel the same way with:
+`pip install target/wheels/*.whl`
+
 ## Environment Settings
 
 Although not required, it is recommended to explicitly apply the settings in this section before using KepLemon to avoid
@@ -27,7 +40,7 @@ unexpected behaviors and inaccurate calculations.
 
 ### CPU Limits
 
-By default, KepLemon will have access to all available cores when performing parallel functions.  Limit this by calling
+By default, KepLemon will have access to all available cores when performing parallel functions. Limit this by calling
 `set_thread_count` **_before_** using other KepLemon functions.
 
 ```python
@@ -39,9 +52,9 @@ set_thread_count(4)
 
 ### Time Constants and Earth-Orientation Parameters (EOP)
 
-All astrodynamics packages have a strict dependence on measured changes to time and Earth's orientation.  Since KepLemon
+All astrodynamics packages have a strict dependence on measured changes to time and Earth's orientation. Since KepLemon
 uses the public Standardized Astrodynamics Algorithms Library (SAAL) at the core, the time and (EOP) data must conform
-to a specific format required by the underlying binaries.  Rather than referencing data directly provided by the
+to a specific format required by the underlying binaries. Rather than referencing data directly provided by the
 [USNO](https://maia.usno.navy.mil/), utility scripts are provided in KepLemon to request and export the relevant data.
 
 #### Global Update
@@ -61,8 +74,8 @@ keplemon --update-eop custom_path.txt
 ```
 
 !!! note
-    If you intend to use the data written to a local override, you must use the `load_time_constants` method at the
-    beginning of your scripts.  **_This is not needed if you maintain constants using the global method_**.
+If you intend to use the data written to a local override, you must use the `load_time_constants` method at the
+beginning of your scripts. **_This is not needed if you maintain constants using the global method_**.
 
 ```python
 from keplemon.time import load_time_constants
@@ -73,5 +86,5 @@ load_time_constants("custom_path.txt")
 
 ## Contributing
 
-Anyone is welcome to contribute to KepLemon.  Users are encouraged to start by opening issues or forking the repository.
+Anyone is welcome to contribute to KepLemon. Users are encouraged to start by opening issues or forking the repository.
 Changes directly to the baseline may be approved by contacting the owner at <brandon@citra.space>.


### PR DESCRIPTION
## What's in this PR
This pull request adds the ability to build the wheel file for keplemon inside of a docker container, which should eliminate any host package conflicts.

Added a two-stage Dockerfile
- Stage 1 - builder: builds the keplemon wheel inside ghcr.io/pyo3/maturin (manylinux‑ready).
- Stage 2 - export: copies /io/target/wheels to /wheels so BuildKit can export artifacts.

## Why
When following the local build instructions, I ran into the following error:

💥 maturin failed
  Caused by: Error ensuring manylinux_2_17 compliance
  Caused by: Your library is not manylinux_2_17 (aka manylinux2014) compliant because of the presence of too-recent versioned symbols: ["libc.so.6 offending symbols: pthread_setname_np@GLIBC_2.34 ..."]. Consider building in a manylinux docker container
Error while executing command, exit code: 1

## How to build
You need to have [Docker](https://docs.docker.com/engine/install/) installed. You can either set the environment variables `OS`, `ARCH`, and `PYTHON_VERSION`, or you can use the defaults `linux`, `amd`, and `310` if those happen to match your system. Run the following command. 

```bash
docker buildx build \
  --build-arg OS="${OS:-linux}" \
  --build-arg ARCH="${ARCH:-amd}" \
  --build-arg PYTHON_VERSION="${PYTHON_VERSION:-310}" \
  --output type=local,dest=./target .
```

The new wheel file should be in target/wheels.