### PR TITLE
Update least squares

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "keplemon"
-version = "1.5.0"
+version = "1.5.1"
 edition = "2021"
 
 [dependencies]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "keplemon"
-version = "1.5.0"
+version = "1.5.1"
 dependencies = ["requests", "click"]
 description = "Citra Space Corporation's Rust-accelerated astrodynamics library."
 authors = [{ name = "Brandon Sexton", email = "brandon@citra.space" }]

--- a/src/bodies/satellite.rs
+++ b/src/bodies/satellite.rs
@@ -60,7 +60,7 @@ impl Satellite {
         match self.inertial_propagator {
             Some(ref propagator) => {
                 new_satellite.inertial_propagator = Some(propagator.new_with_delta_x(delta_x, use_drag, use_srp)?);
-                // Get keplerian state and force properties from the NEW propagator, not the old one!
+                // Get keplerian state and force properties from the new propagator
                 new_satellite.keplerian_state = Some(new_satellite.inertial_propagator.as_ref().unwrap().get_keplerian_state().unwrap());
                 new_satellite.force_properties = new_satellite.inertial_propagator.as_ref().unwrap().get_force_properties().unwrap();
             }

--- a/src/bodies/satellite.rs
+++ b/src/bodies/satellite.rs
@@ -60,8 +60,9 @@ impl Satellite {
         match self.inertial_propagator {
             Some(ref propagator) => {
                 new_satellite.inertial_propagator = Some(propagator.new_with_delta_x(delta_x, use_drag, use_srp)?);
-                new_satellite.keplerian_state = Some(propagator.get_keplerian_state().unwrap());
-                new_satellite.force_properties = propagator.get_force_properties().unwrap();
+                // Get keplerian state and force properties from the NEW propagator, not the old one!
+                new_satellite.keplerian_state = Some(new_satellite.inertial_propagator.as_ref().unwrap().get_keplerian_state().unwrap());
+                new_satellite.force_properties = new_satellite.inertial_propagator.as_ref().unwrap().get_force_properties().unwrap();
             }
             None => return Err("Inertial propagator is not set".to_string()),
         };

--- a/src/elements/tle.rs
+++ b/src/elements/tle.rs
@@ -211,7 +211,6 @@ impl TLE {
             new_elements[i] += delta_x[i];
         }
         let mut forces = self.get_force_properties();
-        
         if use_drag {
             forces.set_drag_coefficient(forces.get_drag_coefficient() + delta_x[6]);
         }

--- a/src/elements/tle.rs
+++ b/src/elements/tle.rs
@@ -211,6 +211,7 @@ impl TLE {
             new_elements[i] += delta_x[i];
         }
         let mut forces = self.get_force_properties();
+        
         if use_drag {
             forces.set_drag_coefficient(forces.get_drag_coefficient() + delta_x[6]);
         }

--- a/src/estimation/batch_least_squares.rs
+++ b/src/estimation/batch_least_squares.rs
@@ -96,24 +96,15 @@ impl BatchLeastSquares {
     }
 
     pub fn solve(&mut self) -> PyResult<()> {
-        println!("solve() called. use_drag={}, use_srp={}", self.use_drag, self.use_srp);
         self.iteration_count = 0;
         self.converged = false;
         self.delta_x = None;
         self.weighted_rms = None;
         let last_epoch = self.obs.iter().map(|o| o.get_epoch()).max().unwrap();
-        println!("About to clone_at_epoch to {:?}", last_epoch);
         self.current_estimate = match self.current_estimate.clone_at_epoch(last_epoch) {
-            Ok(satellite) => {
-                println!("clone_at_epoch succeeded");
-                satellite
-            },
-            Err(e) => {
-                println!("clone_at_epoch failed: {}", e);
-                return Err(pyo3::exceptions::PyRuntimeError::new_err(e));
-            },
+            Ok(satellite) => satellite,
+            Err(e) => return Err(pyo3::exceptions::PyRuntimeError::new_err(e)),
         };
-        println!("Starting iterations...");
         for _ in 0..self.max_iterations {
             match self.iterate() {
                 Ok(_) => {

--- a/src/estimation/batch_least_squares.rs
+++ b/src/estimation/batch_least_squares.rs
@@ -24,6 +24,66 @@ pub struct BatchLeastSquares {
     output_keplerian_type: KeplerianType,
 }
 
+// helper functions (not exposed to Python)
+impl BatchLeastSquares {
+    /// Wrap Right Ascension residuals to [-180°, 180°] for shortest angular distance
+    /// Measurement vector is [RA1, DEC1, RA2, DEC2, ...], so every even index is RA
+    fn wrap_ra_residuals(residuals: &mut DVector<f64>) {
+        for i in (0..residuals.len()).step_by(2) {
+            if residuals[i] > 180.0 {
+                residuals[i] -= 360.0;
+            } else if residuals[i] < -180.0 {
+                residuals[i] += 360.0;
+            }
+        }
+    }
+
+    /// Compute normal equations (H^T * W * H and H^T * W * r) using memory-efficient
+    /// element-wise operations for diagonal weight matrix W
+    /// Returns: (normal_matrix, rhs_vector, weighted_rss)
+    fn compute_normal_equations(
+        h: &DMatrix<f64>,
+        w: &DVector<f64>,
+        r: &DVector<f64>,
+    ) -> (DMatrix<f64>, DVector<f64>, f64) {
+        let n_cols = h.ncols();
+        let mut n = DMatrix::zeros(n_cols, n_cols);
+        let mut b = DVector::zeros(n_cols);
+        let mut wrss = 0.0;
+
+        // H^T * W * H = sum_i(w_i * h_i * h_i^T) where h_i is the i-th row of H
+        // H^T * W * r = sum_i(w_i * h_i * r_i)
+        for (h_row, (&weight, &residual)) in h.row_iter().zip(w.iter().zip(r.iter())) {
+            let wr = weight * residual;
+
+            // Accumulate b = H^T * W * r
+            for (j, &h_ij) in h_row.iter().enumerate() {
+                b[j] += h_ij * wr;
+            }
+
+            // Accumulate n = H^T * W * H (symmetric, so only compute upper triangle)
+            for j in 0..n_cols {
+                let wh_j = weight * h_row[j];
+                for k in j..n_cols {
+                    n[(j, k)] += wh_j * h_row[k];
+                }
+            }
+
+            // Accumulate weighted residual sum of squares
+            wrss += weight * residual * residual;
+        }
+
+        // Fill lower triangle of symmetric matrix
+        for j in 0..n_cols {
+            for k in 0..j {
+                n[(j, k)] = n[(k, j)];
+            }
+        }
+
+        (n, b, wrss)
+    }
+}
+
 #[pymethods]
 impl BatchLeastSquares {
     #[new]
@@ -320,58 +380,13 @@ impl BatchLeastSquares {
         let y_hat = self.get_predicted_measurements()?;
         let mut r = (&y - &y_hat).clone_owned();
         
-        // Handle Right Ascension wraparound (RA wraps at 360°)
-        // Measurement vector is [RA1, DEC1, RA2, DEC2, ...], so every even index is RA
-        for i in (0..r.len()).step_by(2) {
-            // Wrap residual to [-180°, 180°] for shortest angular distance
-            if r[i] > 180.0 {
-                r[i] -= 360.0;
-            } else if r[i] < -180.0 {
-                r[i] += 360.0;
-            }
-        }
+        Self::wrap_ra_residuals(&mut r);
         
         let h = self.get_jacobians()?;
-        
-        // Memory-efficient diagonal weight matrix operations
-        // Instead of creating W as a full matrix, we apply weights element-wise
-        // H^T * W * H = sum_i(w_i * h_i * h_i^T) where h_i is the i-th row of H
-        // H^T * W * r = sum_i(w_i * h_i * r_i)
-        let n_cols = h.ncols();
-        let mut n = DMatrix::zeros(n_cols, n_cols);
-        let mut b = DVector::zeros(n_cols);
-        let mut wrss = 0.0;
-        
-        // Compute normal equations and weighted residual sum of squares
-        for (h_row, (&weight, &residual)) in h.row_iter().zip(w.iter().zip(r.iter())) {
-            let wr = weight * residual;
-            
-            // Accumulate b = H^T * W * r
-            for (j, &h_ij) in h_row.iter().enumerate() {
-                b[j] += h_ij * wr;
-            }
-            
-            // Accumulate n = H^T * W * H (symmetric, so only compute upper triangle)
-            for j in 0..n_cols {
-                let wh_j = weight * h_row[j];
-                for k in j..n_cols {
-                    n[(j, k)] += wh_j * h_row[k];
-                }
-            }
-            
-            // Accumulate weighted residual sum of squares
-            wrss += weight * residual * residual;
-        }
-        
-        // Fill lower triangle of symmetric matrix
-        for j in 0..n_cols {
-            for k in 0..j {
-                n[(j, k)] = n[(k, j)];
-            }
-        }
+        let (n, b, wrss) = Self::compute_normal_equations(&h, &w, &r);
 
         // Compute weighted RMS for convergence testing
-        let m = r.len() as f64;
+        let m: f64 = r.len() as f64;
         let current_weighted_rms = (wrss / m).sqrt();
         if self.weighted_rms.is_some() && (current_weighted_rms - self.weighted_rms.unwrap()).abs() < 1e-3 {
             self.converged = true;

--- a/src/estimation/batch_least_squares.rs
+++ b/src/estimation/batch_least_squares.rs
@@ -24,66 +24,6 @@ pub struct BatchLeastSquares {
     output_keplerian_type: KeplerianType,
 }
 
-// helper functions (not exposed to Python)
-impl BatchLeastSquares {
-    /// Wrap Right Ascension residuals to [-180°, 180°] for shortest angular distance
-    /// Measurement vector is [RA1, DEC1, RA2, DEC2, ...], so every even index is RA
-    fn wrap_ra_residuals(residuals: &mut DVector<f64>) {
-        for i in (0..residuals.len()).step_by(2) {
-            if residuals[i] > 180.0 {
-                residuals[i] -= 360.0;
-            } else if residuals[i] < -180.0 {
-                residuals[i] += 360.0;
-            }
-        }
-    }
-
-    /// Compute normal equations (H^T * W * H and H^T * W * r) using memory-efficient
-    /// element-wise operations for diagonal weight matrix W
-    /// Returns: (normal_matrix, rhs_vector, weighted_rss)
-    fn compute_normal_equations(
-        h: &DMatrix<f64>,
-        w: &DVector<f64>,
-        r: &DVector<f64>,
-    ) -> (DMatrix<f64>, DVector<f64>, f64) {
-        let n_cols = h.ncols();
-        let mut n = DMatrix::zeros(n_cols, n_cols);
-        let mut b = DVector::zeros(n_cols);
-        let mut wrss = 0.0;
-
-        // H^T * W * H = sum_i(w_i * h_i * h_i^T) where h_i is the i-th row of H
-        // H^T * W * r = sum_i(w_i * h_i * r_i)
-        for (h_row, (&weight, &residual)) in h.row_iter().zip(w.iter().zip(r.iter())) {
-            let wr = weight * residual;
-
-            // Accumulate b = H^T * W * r
-            for (j, &h_ij) in h_row.iter().enumerate() {
-                b[j] += h_ij * wr;
-            }
-
-            // Accumulate n = H^T * W * H (symmetric, so only compute upper triangle)
-            for j in 0..n_cols {
-                let wh_j = weight * h_row[j];
-                for k in j..n_cols {
-                    n[(j, k)] += wh_j * h_row[k];
-                }
-            }
-
-            // Accumulate weighted residual sum of squares
-            wrss += weight * residual * residual;
-        }
-
-        // Fill lower triangle of symmetric matrix
-        for j in 0..n_cols {
-            for k in 0..j {
-                n[(j, k)] = n[(k, j)];
-            }
-        }
-
-        (n, b, wrss)
-    }
-}
-
 #[pymethods]
 impl BatchLeastSquares {
     #[new]
@@ -380,10 +320,10 @@ impl BatchLeastSquares {
         let y_hat = self.get_predicted_measurements()?;
         let mut r = (&y - &y_hat).clone_owned();
         
-        Self::wrap_ra_residuals(&mut r);
-        
+        wrap_ra_residuals(&mut r);
+
         let h = self.get_jacobians()?;
-        let (n, b, wrss) = Self::compute_normal_equations(&h, &w, &r);
+        let (n, b, wrss) = compute_normal_equations(&h, &w, &r);
 
         // Compute weighted RMS for convergence testing
         let m: f64 = r.len() as f64;
@@ -400,4 +340,62 @@ impl BatchLeastSquares {
             None => Err("Unable to compute delta_x".to_string()),
         }
     }
+}
+
+
+/// Wrap Right Ascension residuals to [-180°, 180°] for shortest angular distance
+/// Measurement vector is [RA1, DEC1, RA2, DEC2, ...], so every even index is RA
+fn wrap_ra_residuals(residuals: &mut DVector<f64>) {
+    for i in (0..residuals.len()).step_by(2) {
+        if residuals[i] > 180.0 {
+            residuals[i] -= 360.0;
+        } else if residuals[i] < -180.0 {
+            residuals[i] += 360.0;
+        }
+    }
+}
+
+/// Compute normal equations (H^T * W * H and H^T * W * r) using memory-efficient
+/// element-wise operations for diagonal weight matrix W
+/// Returns: (normal_matrix, rhs_vector, weighted_rss)
+fn compute_normal_equations(
+    h: &DMatrix<f64>,
+    w: &DVector<f64>,
+    r: &DVector<f64>,
+) -> (DMatrix<f64>, DVector<f64>, f64) {
+    let n_cols = h.ncols();
+    let mut n = DMatrix::zeros(n_cols, n_cols);
+    let mut b = DVector::zeros(n_cols);
+    let mut wrss = 0.0;
+
+    // H^T * W * H = sum_i(w_i * h_i * h_i^T) where h_i is the i-th row of H
+    // H^T * W * r = sum_i(w_i * h_i * r_i)
+    for (h_row, (&weight, &residual)) in h.row_iter().zip(w.iter().zip(r.iter())) {
+        let wr = weight * residual;
+
+        // Accumulate b = H^T * W * r
+        for (j, &h_ij) in h_row.iter().enumerate() {
+            b[j] += h_ij * wr;
+        }
+
+        // Accumulate n = H^T * W * H (symmetric, so only compute upper triangle)
+        for j in 0..n_cols {
+            let wh_j = weight * h_row[j];
+            for k in j..n_cols {
+                n[(j, k)] += wh_j * h_row[k];
+            }
+        }
+
+        // Accumulate weighted residual sum of squares
+        wrss += weight * residual * residual;
+    }
+
+    // Fill lower triangle of symmetric matrix
+    for j in 0..n_cols {
+        for k in 0..j {
+            n[(j, k)] = n[(k, j)];
+        }
+    }
+
+    (n, b, wrss)
 }

--- a/src/estimation/batch_least_squares.rs
+++ b/src/estimation/batch_least_squares.rs
@@ -96,15 +96,24 @@ impl BatchLeastSquares {
     }
 
     pub fn solve(&mut self) -> PyResult<()> {
+        println!("solve() called. use_drag={}, use_srp={}", self.use_drag, self.use_srp);
         self.iteration_count = 0;
         self.converged = false;
         self.delta_x = None;
         self.weighted_rms = None;
         let last_epoch = self.obs.iter().map(|o| o.get_epoch()).max().unwrap();
+        println!("About to clone_at_epoch to {:?}", last_epoch);
         self.current_estimate = match self.current_estimate.clone_at_epoch(last_epoch) {
-            Ok(satellite) => satellite,
-            Err(e) => return Err(pyo3::exceptions::PyRuntimeError::new_err(e)),
+            Ok(satellite) => {
+                println!("clone_at_epoch succeeded");
+                satellite
+            },
+            Err(e) => {
+                println!("clone_at_epoch failed: {}", e);
+                return Err(pyo3::exceptions::PyRuntimeError::new_err(e));
+            },
         };
+        println!("Starting iterations...");
         for _ in 0..self.max_iterations {
             match self.iterate() {
                 Ok(_) => {
@@ -216,7 +225,6 @@ impl BatchLeastSquares {
 
         // Seed drag if not already set
         if self.get_estimate_drag() && force_properties.get_drag_coefficient() == 0.0 {
-            println!("Seeding drag force properties");
             force_properties.set_drag_coefficient(configs::DEFAULT_DRAG_TERM);
             force_properties.set_drag_area(1.0);
             force_properties.set_mass(1.0);
@@ -272,7 +280,7 @@ impl BatchLeastSquares {
 }
 
 impl BatchLeastSquares {
-    fn get_measurements_and_weights(&self) -> (DVector<f64>, DMatrix<f64>) {
+    fn get_measurements_and_weights(&self) -> (DVector<f64>, DVector<f64>) {
         let mut measurement_vec = Vec::new();
         let mut weight_diag = Vec::new();
         self.obs.iter().for_each(|ob| {
@@ -281,8 +289,8 @@ impl BatchLeastSquares {
             weight_diag.extend(w_vec);
         });
         let measurement_vector = DVector::from_vec(measurement_vec);
-        let weight_matrix = DMatrix::from_diagonal(&DVector::from_vec(weight_diag));
-        (measurement_vector, weight_matrix)
+        let weight_vector = DVector::from_vec(weight_diag);
+        (measurement_vector, weight_vector)
     }
 
     fn get_predicted_measurements(&self) -> Result<DVector<f64>, String> {
@@ -319,15 +327,60 @@ impl BatchLeastSquares {
     fn get_delta_x(&mut self) -> Result<(), String> {
         let (y, w) = self.get_measurements_and_weights();
         let y_hat = self.get_predicted_measurements()?;
-        let r = &y - &y_hat;
+        let mut r = (&y - &y_hat).clone_owned();
+        
+        // Handle Right Ascension wraparound (RA wraps at 360°)
+        // Measurement vector is [RA1, DEC1, RA2, DEC2, ...], so every even index is RA
+        for i in (0..r.len()).step_by(2) {
+            // Wrap residual to [-180°, 180°] for shortest angular distance
+            if r[i] > 180.0 {
+                r[i] -= 360.0;
+            } else if r[i] < -180.0 {
+                r[i] += 360.0;
+            }
+        }
+        
         let h = self.get_jacobians()?;
-        let h_transpose_w = &h.transpose() * &w;
-        let n = &h_transpose_w * &h;
-        let b = &h_transpose_w * &r;
+        
+        // Memory-efficient diagonal weight matrix operations
+        // Instead of creating W as a full matrix, we apply weights element-wise
+        // H^T * W * H = sum_i(w_i * h_i * h_i^T) where h_i is the i-th row of H
+        // H^T * W * r = sum_i(w_i * h_i * r_i)
+        let n_cols = h.ncols();
+        let mut n = DMatrix::zeros(n_cols, n_cols);
+        let mut b = DVector::zeros(n_cols);
+        let mut wrss = 0.0;
+        
+        // Compute normal equations and weighted residual sum of squares
+        for (h_row, (&weight, &residual)) in h.row_iter().zip(w.iter().zip(r.iter())) {
+            let wr = weight * residual;
+            
+            // Accumulate b = H^T * W * r
+            for (j, &h_ij) in h_row.iter().enumerate() {
+                b[j] += h_ij * wr;
+            }
+            
+            // Accumulate n = H^T * W * H (symmetric, so only compute upper triangle)
+            for j in 0..n_cols {
+                let wh_j = weight * h_row[j];
+                for k in j..n_cols {
+                    n[(j, k)] += wh_j * h_row[k];
+                }
+            }
+            
+            // Accumulate weighted residual sum of squares
+            wrss += weight * residual * residual;
+        }
+        
+        // Fill lower triangle of symmetric matrix
+        for j in 0..n_cols {
+            for k in 0..j {
+                n[(j, k)] = n[(k, j)];
+            }
+        }
 
-        // Compute weighted RMS for convergence testing and noise balancing
+        // Compute weighted RMS for convergence testing
         let m = r.len() as f64;
-        let wrss = (r.transpose() * &w * &r)[(0, 0)];
         let current_weighted_rms = (wrss / m).sqrt();
         if self.weighted_rms.is_some() && (current_weighted_rms - self.weighted_rms.unwrap()).abs() < 1e-3 {
             self.converged = true;


### PR DESCRIPTION
Fix two bugs:
- Force properties not persisting (in Satellite::new_with_delta_x) when drag or srp were enabled
- RA wraparound fix - without it, the solver sees 360° errors that don't exist and makes huge corrections in the wrong direction

And improve memory usage by calculating diagonals directly (`weight_matrix` -> `weight_vector`) saving a lot of memory on larger observation sets.